### PR TITLE
Use node-which to resolve executable path for all platforms

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-process.execPath = require.resolve('.bin/babel-node');
+var which = require('which');
+process.execPath = which.sync('babel-node');
 require('tap/bin/run.js');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/testiumjs/babel-tap#readme",
   "dependencies": {
     "babel-cli": "^6.0.0",
-    "tap": ">=2.1.0"
+    "tap": ">=2.1.0",
+    "which": "^1.2.12"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
The call of `require('.bin/tap')` will lead to a missing path error on Windows. It's recommended to use node-which to resolve executable path.